### PR TITLE
Predefined variable fix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Run mypy
         run: make mypy
       - name: Run unit tests
-        run: make test
+        run: make ARGS="--exitfirst" test
       - name: Build docs
         run: make docs
       - name: Deploy docs

--- a/prodigy/analysis/instruction_handler.py
+++ b/prodigy/analysis/instruction_handler.py
@@ -439,7 +439,7 @@ class ObserveHandler(InstructionHandler):
         unsat_part = distribution - sat_part
         so_vars = prog_info.so_vars
         if so_vars is None or len(so_vars) == 0:
-            unsat_prob = unsat_part.get_probability_mass()
+            unsat_prob: Distribution | str = unsat_part.get_probability_mass()
         else:
             unsat_prob = unsat_part.marginal(*so_vars)
         res_error_prob = error_prob + unsat_prob

--- a/prodigy/distribution/distribution.py
+++ b/prodigy/distribution/distribution.py
@@ -323,9 +323,8 @@ class Distribution(ABC):
         Creates a list of subdistributions where at list index i, the `variable` is congruent i modulo `modulus`.
         """
 
-    @staticmethod
     @abstractmethod
-    def _find_symbols(expr: str) -> Set[str]:
+    def _find_symbols(self, expr: str) -> Set[str]:
         "Returns a set of all free symbols in the given expression."
 
     def get_symbols(self) -> Set[str]:

--- a/prodigy/distribution/distribution.py
+++ b/prodigy/distribution/distribution.py
@@ -128,7 +128,7 @@ class Distribution(ABC):
     def copy(self, deep: bool = True) -> Distribution:
         """ Returns a full copy of itself."""
 
-    def get_probability_of(self, condition: Union[Expr, str]):
+    def get_probability_of(self, condition: Union[Expr, str]) -> str:
         """
         Returns the probability of a given `condition` or variable.
 
@@ -143,7 +143,7 @@ class Distribution(ABC):
         return self.filter(expr).get_probability_mass()
 
     @abstractmethod
-    def get_probability_mass(self) -> Union[Expr, str]:
+    def get_probability_mass(self) -> str:
         """ Returns the probability mass of the distribution. """
 
     @abstractmethod

--- a/prodigy/distribution/fast_generating_function.py
+++ b/prodigy/distribution/fast_generating_function.py
@@ -201,8 +201,7 @@ class FPS(Distribution):
     def get_parameters(self) -> Set[str]:
         return self._parameters
 
-    @staticmethod
-    def _find_symbols(expr: str) -> Set[str]:
+    def _find_symbols(self, expr: str) -> Set[str]:
         return set(pygin.find_symbols(expr))
 
     def get_symbols(self) -> Set[str]:

--- a/prodigy/distribution/fast_generating_function.py
+++ b/prodigy/distribution/fast_generating_function.py
@@ -372,7 +372,7 @@ class FPS(Distribution):
             return result
 
         if sampling_dist.function in {"unif", "unif_d"}:
-            start, end = sampling_dist.params[0]
+            [start, end] = sampling_dist.params[0]
             result = self._dist.updateIid(
                 str(variable),
                 pygin.Dist(
@@ -381,21 +381,38 @@ class FPS(Distribution):
                 str(count))
             return FPS.from_dist(result, self._variables, self._parameters)
 
+        if sampling_dist.function == "binomial":
+            [n, p] = sampling_dist.params[0]
+            result = self._dist.updateIid(
+                str(variable),
+                pygin.Dist(f'(1 - ({p}) + ({p}) * {variable})^({n})'),
+                str(count))
+            return FPS.from_dist(result, self._variables, self._parameters)
+
         [param] = sampling_dist.params[0]
         if sampling_dist.function == "geometric":
-            result = self._dist.updateIid(str(variable),
-                                          pygin.geometric("test", str(param)),
-                                          str(count))
+            result = self._dist.updateIid(
+                str(variable), pygin.geometric(str(variable), str(param)),
+                str(count))
             return FPS.from_dist(result, self._variables, self._parameters)
+
         if sampling_dist.function == "bernoulli":
             result = self._dist.updateIid(
-                str(variable), pygin.Dist(f"{param} * test + (1-{param})"),
-                str(count))
+                str(variable),
+                pygin.Dist(f"{param} * {variable} + (1-{param})"), str(count))
             return FPS.from_dist(result, self._variables, self._parameters)
 
         if sampling_dist.function == "poisson":
             result = self._dist.updateIid(
-                str(variable), pygin.Dist(f"exp({param} * (test - 1))"),
+                str(variable), pygin.Dist(f"exp({param} * ({variable} - 1))"),
+                str(count))
+            return FPS.from_dist(result, self._variables, self._parameters)
+
+        if sampling_dist.function == 'logdist':
+            result = self._dist.updateIid(
+                str(variable),
+                pygin.Dist(
+                    f'log(1 - ({param}) * {variable}) / log(1 - ({param}))'),
                 str(count))
             return FPS.from_dist(result, self._variables, self._parameters)
 

--- a/prodigy/distribution/generating_function.py
+++ b/prodigy/distribution/generating_function.py
@@ -37,11 +37,10 @@ def _parse_to_sympy(expr: Any,
                     nonnegative=True,
                     **kwargs) -> sympy.Expr:
     """
-    Parses something to a sympy expression. Can convert a probably expression
-    faster than passing it as a string to sympy. Also will correctly determine if
-    something is a symbol or a function (e.g., if we have a variable called `exp` or
-    `log`). All symbols are given the assumptions that they are rational and nonnegative
-    unless specified otherwise.
+    Parses something (`float`s, `bool`s, `Fraction`s, `probably.Expr`s, anything that can be converted to a valid
+    string) to a sympy expression. Can convert a probably expression faster than passing it as a string to sympy.
+    Also will correctly determine if something is a symbol or a function (e.g., if we have a variable called `exp` or
+    `log`). All symbols are given the assumptions that they are rational and nonnegative unless specified otherwise.
     """
 
     # first we cover some cases that we can handle faster than by parsing a string
@@ -131,7 +130,8 @@ def _sympy_symbol(name: Any,
     Creates a rational and nonnegative sympy Symbol.
     
     Note that `sympy.Symbol('x') == sympy.Symbol('x', rational=True, nonnegative=True)`
-    is false.
+    evaluates to false, as variables with the same name but different domains are not considered
+    equal by sympy.
     """
     return sympy.Symbol(name,
                         rational=rational,

--- a/prodigy/distribution/generating_function.py
+++ b/prodigy/distribution/generating_function.py
@@ -32,12 +32,12 @@ def _term_generator(function: sympy.Poly):
         poly -= poly.EC() * poly.EM().as_expr()
 
 
-def _parse_to_sympy(expr: Any, rational=True, **kwargs) -> sympy.Expr:
+def _parse_to_sympy(expr: Any, real=True, **kwargs) -> sympy.Expr:
     """
     Parses something (`float`s, `bool`s, `Fraction`s, `probably.Expr`s, anything that can be converted to a valid
     string) to a sympy expression. Can convert a probably expression faster than passing it as a string to sympy.
     Also will correctly determine if something is a symbol or a function (e.g., if we have a variable called `exp` or
-    `log`). All symbols are given the assumptions that they are rational and nonnegative unless specified otherwise.
+    `log`). All symbols are given the assumptions that they are real unless specified otherwise.
     """
 
     # first we cover some cases that we can handle faster than by parsing a string
@@ -58,7 +58,7 @@ def _parse_to_sympy(expr: Any, rational=True, **kwargs) -> sympy.Expr:
 
         def probably_to_sympy(prob_expr: Expr) -> sympy.Expr:
             if isinstance(prob_expr, VarExpr):
-                return _sympy_symbol(prob_expr.var, rational, **kwargs)
+                return _sympy_symbol(prob_expr.var, real, **kwargs)
             if isinstance(prob_expr, NatLitExpr):
                 return sympy.Integer(prob_expr.value)
             if isinstance(prob_expr, RealLitExpr):
@@ -103,7 +103,7 @@ def _parse_to_sympy(expr: Any, rational=True, **kwargs) -> sympy.Expr:
             + (sympy.parsing.sympy_parser.convert_xor,
                sympy.parsing.sympy_parser.rationalize),
             global_dict={
-                'Symbol': lambda x: _sympy_symbol(x, rational, **kwargs),
+                'Symbol': lambda x: _sympy_symbol(x, real, **kwargs),
                 'Function': get_function,
                 'Integer': sympy.Integer,
                 'Float': sympy.Float,
@@ -113,15 +113,14 @@ def _parse_to_sympy(expr: Any, rational=True, **kwargs) -> sympy.Expr:
     return s
 
 
-def _sympy_symbol(name: Any, rational=True, **kwargs) -> sympy.Symbol:
+def _sympy_symbol(name: Any, real=True, **kwargs) -> sympy.Symbol:
     """
-    Creates a rational and nonnegative sympy Symbol.
+    Creates a real sympy Symbol.
     
-    Note that `sympy.Symbol('x') == sympy.Symbol('x', rational=True, nonnegative=True)`
-    evaluates to false, as variables with the same name but different domains are not considered
-    equal by sympy.
+    Note that `sympy.Symbol('x') == sympy.Symbol('x', real=True)` evaluates to false, as variables
+    with the same name but different domains are not considered equal by sympy.
     """
-    return sympy.Symbol(name, rational=rational, **kwargs)
+    return sympy.Symbol(name, real=real, **kwargs)
 
 
 class GeneratingFunction(Distribution):

--- a/prodigy/distribution/generating_function.py
+++ b/prodigy/distribution/generating_function.py
@@ -960,7 +960,7 @@ class GeneratingFunction(Distribution):
 
     def copy(self, deep: bool = True) -> GeneratingFunction:
         res = GeneratingFunction(
-            str(self._function),  # TODO remove str?
+            self._function,
             *self._variables,
             preciseness=self._preciseness,
             closed=self._is_closed_form,

--- a/prodigy/distribution/generating_function.py
+++ b/prodigy/distribution/generating_function.py
@@ -297,21 +297,6 @@ class GeneratingFunction(Distribution):
                                    finite=self._is_finite))
         return result
 
-    def _limit(self, variable: Union[str, sympy.Symbol],
-               value: Union[str, sympy.Expr]) -> GeneratingFunction:
-        func = self._function
-        if self._is_closed_form:
-            print("\rComputing limit...", end="\r", flush=True)
-            func = func.limit(_sympy_symbol(variable), _parse_to_sympy(value),
-                              "-")
-            # func = func.subs(_parse_to_sympy(variable), _parse_to_sympy(value))
-        else:
-            func = func.subs(_sympy_symbol(variable), _parse_to_sympy(value))
-        return GeneratingFunction(func,
-                                  preciseness=self._preciseness,
-                                  closed=self._is_closed_form,
-                                  finite=func.ratsimp().is_polynomial())
-
     @staticmethod
     def _split_addend(addend: sympy.Expr) -> Tuple[sympy.Expr, sympy.Expr]:
         r"""
@@ -1163,24 +1148,6 @@ class GeneratingFunction(Distribution):
             return map(
                 lambda term: (str(term[0]), self._monomial_to_state(term[1])),
                 self._mult_term_generator())
-
-    def _diff(self, variable, k):
-        r"""
-        Partial `k`-th derivative of the generating function with respect to variable `variable`.
-
-        :param variable: The variable in which the generating function gets differentiated.
-
-        :param k: The order of the partial derivative.
-
-        :return: The `k`-th partial derivative of the generating function in `variable`
-
-        .. math:: \fraction{\delta G^`k`}{\delta `var`^`k`}
-        """
-        logger.debug("diff Call")
-        return GeneratingFunction(sympy.diff(self._function,
-                                             _sympy_symbol(variable), k),
-                                  *self._variables,
-                                  preciseness=self._preciseness)
 
     # FIXME: It's not nice to have different behaviour depending on the variable type of `threshold`.
     def approximate(

--- a/tests/analysis/test_distribution_transformer.py
+++ b/tests/analysis/test_distribution_transformer.py
@@ -1,43 +1,45 @@
 import random
 
 import probably.pgcl as pgcl
-import sympy
+import pytest
 from pytest import raises
 
 import prodigy.analysis
-from prodigy.distribution.generating_function import GeneratingFunction as GF
+from prodigy.analysis.config import ForwardAnalysisConfig
+from prodigy.distribution.fast_generating_function import ProdigyPGF
 from prodigy.distribution.generating_function import SympyPGF
 
 
-def test_context_injection():
+@pytest.mark.parametrize('engine,factory',
+                         [(ForwardAnalysisConfig.Engine.SYMPY, SympyPGF),
+                          (ForwardAnalysisConfig.Engine.GINAC, ProdigyPGF)])
+def test_context_injection(engine, factory):
     program = pgcl.parse_pgcl("""
         nat x;
         nat y;
         rparam p;
         nparam n;
         """)
-    gf = GF("z^3")
+    gf = factory.from_expr("z^3")
     result = prodigy.analysis.compute_discrete_distribution(
-        program, gf, prodigy.analysis.ForwardAnalysisConfig())
+        program, gf, prodigy.analysis.ForwardAnalysisConfig(engine=engine))
     assert result.get_variables() == {
         "x", "y", "z"
     } and result.get_parameters() == {"p", "n"}
 
 
-def test_iid_predefined_distributions():
+@pytest.mark.parametrize('engine,factory',
+                         [(ForwardAnalysisConfig.Engine.SYMPY, SympyPGF),
+                          (ForwardAnalysisConfig.Engine.GINAC, ProdigyPGF)])
+def test_iid_predefined_distributions(engine, factory):
     distributions = {
-        "geometric(p)":
-        SympyPGF.geometric("x", "p").set_parameters("p", "n"),
-        "binomial(n,p)":
-        SympyPGF.binomial("x", "n", "p"),
-        "poisson(n)":
-        SympyPGF.poisson("x", "n").set_parameters("p", "n"),
-        "bernoulli(p)":
-        SympyPGF.bernoulli("x", "p").set_parameters("p", "n"),
-        "unif(n, n+10)":
-        SympyPGF.uniform("x", "n", "n+10").set_parameters("p", "n"),
-        "logdist(p)":
-        SympyPGF.log("x", "p").set_parameters("p", "n")
+        "geometric(p)": factory.geometric("x", "p").set_parameters("p", "n"),
+        "binomial(n,p)": factory.binomial("x", "n", "p"),
+        "poisson(n)": factory.poisson("x", "n").set_parameters("p", "n"),
+        "bernoulli(p)": factory.bernoulli("x", "p").set_parameters("p", "n"),
+        "unif(n, n+10)": factory.uniform("x", "n",
+                                         "n+10").set_parameters("p", "n"),
+        "logdist(p)": factory.log("x", "p").set_parameters("p", "n")
     }
 
     for distribution in distributions.keys():
@@ -48,12 +50,15 @@ def test_iid_predefined_distributions():
                     rparam p;
                     
                     x := iid(%s, x);
-                """ % distribution), GF("x"),
-            prodigy.analysis.ForwardAnalysisConfig())
+                """ % distribution), factory.from_expr('x', 'x'),
+            ForwardAnalysisConfig(engine=engine))
         assert result == distributions[distribution], distribution
 
 
-def test_iid_update():
+@pytest.mark.parametrize('engine,factory',
+                         [(ForwardAnalysisConfig.Engine.SYMPY, SympyPGF),
+                          (ForwardAnalysisConfig.Engine.GINAC, ProdigyPGF)])
+def test_iid_update(engine, factory):
     result = prodigy.analysis.compute_discrete_distribution(
         pgcl.parse_pgcl("""
             nat x;
@@ -61,68 +66,85 @@ def test_iid_update():
             
             x := binomial(5,p);
             x := iid(geometric(p), x);
-        """), GF("1"), prodigy.analysis.ForwardAnalysisConfig())
-    assert result == GF("(p^2/(1-(1-p)*x) + 1 - p)^5", "x")
+        """), factory.one('x'),
+        prodigy.analysis.ForwardAnalysisConfig(engine=engine))
+    assert result == factory.from_expr("(p^2/(1-(1-p)*x) + 1 - p)^5", "x")
 
 
-def test_subtraction_when_already_zero():
-    with raises(ValueError) as e:
+@pytest.mark.parametrize('engine,factory',
+                         [(ForwardAnalysisConfig.Engine.SYMPY, SympyPGF),
+                          (ForwardAnalysisConfig.Engine.GINAC, ProdigyPGF)])
+def test_subtraction_when_already_zero(engine, factory):
+    with raises(ValueError, match='negative') as e:
         result = prodigy.analysis.compute_discrete_distribution(
             pgcl.parse_pgcl("""
-        nat n;
-        n := 0;
-        n := n-1;
-        """), GF("n^5"), prodigy.analysis.ForwardAnalysisConfig())
-    assert "Cannot assign '_0 - 1' to 'n' because it can be negative" in str(e)
+        nat x;
+        x := 0;
+        x := x-1;
+        """), factory.from_expr("x^5"),
+            prodigy.analysis.ForwardAnalysisConfig(engine=engine))
 
     result = prodigy.analysis.compute_discrete_distribution(
         pgcl.parse_pgcl("""
-    nat n;
-    n := 0;
-    n := n - 2*n;
-    """), GF("n^5"), prodigy.analysis.ForwardAnalysisConfig())
-    assert result == GF("1", "n")
+    nat x;
+    x := 0;
+    x := x - 2*x;
+    """), factory.from_expr("x^5"),
+        prodigy.analysis.ForwardAnalysisConfig(engine=engine))
+    assert result == factory.from_expr("1", "x")
 
     with raises(ValueError) as e:
-        result: GF = prodigy.analysis.compute_discrete_distribution(
+        result = prodigy.analysis.compute_discrete_distribution(
             pgcl.parse_pgcl("""
             nat x
             x := x - 2*x
-        """), SympyPGF.poisson("x", "3"),
-            prodigy.analysis.ForwardAnalysisConfig())
+        """), factory.poisson("x", "3"),
+            prodigy.analysis.ForwardAnalysisConfig(engine=engine))
     assert 'Cannot assign' in str(e)
 
 
-def test_addition_assignment():
+@pytest.mark.parametrize('engine,factory',
+                         [(ForwardAnalysisConfig.Engine.SYMPY, SympyPGF),
+                          (ForwardAnalysisConfig.Engine.GINAC, ProdigyPGF)])
+def test_addition_assignment(engine, factory):
     rand_inc = random.randint(0, 100)
     rand_init = random.randint(0, 100)
     result = prodigy.analysis.compute_discrete_distribution(
         pgcl.parse_pgcl(f"""
-        nat n;
-        n := n+{rand_inc};
-        """), GF(f"n^{rand_init}"), prodigy.analysis.ForwardAnalysisConfig())
-    assert result == GF(f"n^{rand_init + rand_inc}", "n")
+        nat x;
+        x := x+{rand_inc};
+        """), factory.from_expr(f"x^{rand_init}"),
+        prodigy.analysis.ForwardAnalysisConfig(engine=engine))
+    assert result == factory.from_expr(f"x^{rand_init + rand_inc}", "x")
 
 
-def test_multiplication_assignment():
+@pytest.mark.parametrize('engine,factory',
+                         [(ForwardAnalysisConfig.Engine.SYMPY, SympyPGF),
+                          (ForwardAnalysisConfig.Engine.GINAC, ProdigyPGF)])
+def test_multiplication_assignment(engine, factory):
     rand_factor = random.randint(0, 100)
     rand_init = random.randint(0, 100)
     result = prodigy.analysis.compute_discrete_distribution(
         pgcl.parse_pgcl(f"""
-        nat n;
-        n := n*{rand_factor};
-        """), GF(f"n^{rand_init}"), prodigy.analysis.ForwardAnalysisConfig())
-    assert result == GF(f"n^{rand_init * rand_factor}", "n")
+        nat x;
+        x := x*{rand_factor};
+        """), factory.from_expr(f"x^{rand_init}"),
+        prodigy.analysis.ForwardAnalysisConfig(engine=engine))
+    assert result == factory.from_expr(f"x^{rand_init * rand_factor}", "x")
 
     result = prodigy.analysis.compute_discrete_distribution(
         pgcl.parse_pgcl(f"""
-        nat n;
-        n := n*0.5;
-        """), GF(f"n^4"), prodigy.analysis.ForwardAnalysisConfig())
-    assert result == GF(f"n^2", "n")
+        nat x;
+        x := x*0.5;
+        """), factory.from_expr(f"x^4"),
+        prodigy.analysis.ForwardAnalysisConfig(engine=engine))
+    assert result == factory.from_expr(f"x^2", "x")
 
 
-def test_ite_statement():
+@pytest.mark.parametrize('engine,factory',
+                         [(ForwardAnalysisConfig.Engine.SYMPY, SympyPGF),
+                          (ForwardAnalysisConfig.Engine.GINAC, ProdigyPGF)])
+def test_ite_statement(engine, factory):
     result = prodigy.analysis.compute_discrete_distribution(
         pgcl.parse_pgcl("""
         nat x;
@@ -133,5 +155,6 @@ def test_ite_statement():
         } else {
             y := y + 1
         }
-        """), GF("x*y"), prodigy.analysis.ForwardAnalysisConfig())
-    assert result == GF("x*y^2", "x", "y")
+        """), factory.from_expr("x*y"),
+        prodigy.analysis.ForwardAnalysisConfig(engine=engine))
+    assert result == factory.from_expr("x*y^2", "x", "y")

--- a/tests/analysis/test_distribution_transformer.py
+++ b/tests/analysis/test_distribution_transformer.py
@@ -50,7 +50,7 @@ def test_iid_predefined_distributions():
                     x := iid(%s, x);
                 """ % distribution), GF("x"),
             prodigy.analysis.ForwardAnalysisConfig())
-        assert result == distributions[distribution]
+        assert result == distributions[distribution], distribution
 
 
 def test_iid_update():

--- a/tests/analysis/test_equivalence_check.py
+++ b/tests/analysis/test_equivalence_check.py
@@ -10,7 +10,7 @@ from prodigy.analysis.equivalence.equivalence_check import check_equivalence
 @pytest.mark.parametrize(
     'engine',
     [ForwardAnalysisConfig.Engine.GINAC, ForwardAnalysisConfig.Engine.SYMPY])
-def test_equivalence_check_ginac(engine):
+def test_equivalence_check(engine):
     prog = compile_pgcl("""
         nat x;
         nat c;
@@ -45,7 +45,7 @@ def test_equivalence_check_ginac(engine):
 @pytest.mark.parametrize(
     'engine',
     [ForwardAnalysisConfig.Engine.GINAC, ForwardAnalysisConfig.Engine.SYMPY])
-def test_equivalence_check_parameter_ginac(engine):
+def test_equivalence_check_parameter(engine):
     prog = compile_pgcl("""
         nat x;
         nat c;

--- a/tests/analysis/test_equivalence_check.py
+++ b/tests/analysis/test_equivalence_check.py
@@ -1,3 +1,4 @@
+import pytest
 import sympy
 from probably.pgcl.ast import Program
 from probably.pgcl.compiler import compile_pgcl
@@ -6,7 +7,10 @@ from prodigy.analysis.config import ForwardAnalysisConfig
 from prodigy.analysis.equivalence.equivalence_check import check_equivalence
 
 
-def test_equivalence_check_ginac():
+@pytest.mark.parametrize(
+    'engine',
+    [ForwardAnalysisConfig.Engine.GINAC, ForwardAnalysisConfig.Engine.SYMPY])
+def test_equivalence_check_ginac(engine):
     prog = compile_pgcl("""
         nat x;
         nat c;
@@ -32,14 +36,16 @@ def test_equivalence_check_ginac():
         } else {skip}
     """)
     assert isinstance(inv, Program)
-    res, subs = check_equivalence(
-        prog, inv,
-        ForwardAnalysisConfig(engine=ForwardAnalysisConfig.Engine.GINAC))
+    res, subs = check_equivalence(prog, inv,
+                                  ForwardAnalysisConfig(engine=engine))
     assert res
     assert subs == []
 
 
-def test_equivalence_check_parameter_ginac():
+@pytest.mark.parametrize(
+    'engine',
+    [ForwardAnalysisConfig.Engine.GINAC, ForwardAnalysisConfig.Engine.SYMPY])
+def test_equivalence_check_parameter_ginac(engine):
     prog = compile_pgcl("""
         nat x;
         nat c;
@@ -67,78 +73,8 @@ def test_equivalence_check_parameter_ginac():
         } else {skip}
     """)
     assert isinstance(inv, Program)
-    res, subs = check_equivalence(
-        prog, inv,
-        ForwardAnalysisConfig(engine=ForwardAnalysisConfig.Engine.GINAC))
-    assert res
-    assert len(subs) == 1
-    assert sympy.S(subs[0]['p']) == sympy.S('1/2')
-
-
-def test_equivalence_check_sympy():
-    prog = compile_pgcl("""
-        nat x;
-        nat c;
-        nat temp;
-
-        while (x >= 1){
-        {x := 0 } [1/2] {c := c+1}
-        temp :=0
-        }
-    """)
-    assert isinstance(prog, Program)
-
-    inv = compile_pgcl("""
-        nat x;
-        nat c;
-        nat temp;
-
-        if(x >= 1){
-            temp := geometric(1/2)
-            c := c + temp
-            x := 0
-            temp := 0
-        } else {skip}
-    """)
-    assert isinstance(inv, Program)
-    res, subs = check_equivalence(
-        prog, inv,
-        ForwardAnalysisConfig(engine=ForwardAnalysisConfig.Engine.SYMPY))
-    assert res
-    assert subs == []
-
-
-def test_equivalence_check_parameter_sympy():
-    prog = compile_pgcl("""
-        nat x;
-        nat c;
-        nat temp;
-        rparam p;
-
-        while (x >= 1){
-        {x := 0 } [1.0-p] {c := c+1}
-        temp :=0
-        }
-    """)
-    assert isinstance(prog, Program)
-
-    inv = compile_pgcl("""
-        nat x;
-        nat c;
-        nat temp;
-        rparam p;
-
-        if(x >= 1){
-            temp := geometric(p)
-            c := c + temp
-            x := 0
-            temp := 0
-        } else {skip}
-    """)
-    assert isinstance(inv, Program)
-    res, subs = check_equivalence(
-        prog, inv,
-        ForwardAnalysisConfig(engine=ForwardAnalysisConfig.Engine.SYMPY))
+    res, subs = check_equivalence(prog, inv,
+                                  ForwardAnalysisConfig(engine=engine))
     assert res
     assert len(subs) == 1
     assert sympy.S(subs[0]['p']) == sympy.S('1/2')

--- a/tests/distribution/GiNaC/test_fast_generating_function.py
+++ b/tests/distribution/GiNaC/test_fast_generating_function.py
@@ -1,5 +1,6 @@
 import random
 
+import pygin
 import pytest
 from probably.pgcl.ast import Binop, BinopExpr, NatLitExpr, VarExpr
 from probably.pgcl.parser import parse_expr
@@ -220,3 +221,18 @@ class TestDistributionInterface:
         gf = create_random_gf(3, 5)
         gf = gf.set_variables("a", "b", "c")
         assert all([x in gf.get_variables() for x in {'a', 'b', 'c'}])
+
+
+def test_predefined_variable_names():
+    gf = FPS('sum^3*x^5')
+    assert len(gf.get_variables()) == 2
+    assert gf.marginal('sum') == FPS('sum^3', 'sum')
+    assert gf.update(parse_expr('sum = sum + 1')) == FPS(
+        'sum^4*x^5', 'sum', 'x')
+
+    assert ProdigyPGF.bernoulli('sum', '1/2') == FPS('1/2+1/2*sum', 'sum')
+
+    pygin.reset_symbol_cache()
+    gf = FPS('sum*x', 'x')
+    assert len(gf.get_parameters()) == 1
+    assert gf.update(parse_expr('x = 2')) == FPS('sum*x^2', 'x')

--- a/tests/distribution/GiNaC/test_fast_generating_function.py
+++ b/tests/distribution/GiNaC/test_fast_generating_function.py
@@ -223,16 +223,17 @@ class TestDistributionInterface:
         assert all([x in gf.get_variables() for x in {'a', 'b', 'c'}])
 
 
-def test_predefined_variable_names():
-    gf = FPS('sum^3*x^5')
+@pytest.mark.parametrize("name", ['sum', 'exp', 'sign', 'ln', 'log', 'sqrt'])
+def test_predefined_variable_names(name):
+    gf = FPS(f'{name}^3*x^5')
     assert len(gf.get_variables()) == 2
-    assert gf.marginal('sum') == FPS('sum^3', 'sum')
-    assert gf.update(parse_expr('sum = sum + 1')) == FPS(
-        'sum^4*x^5', 'sum', 'x')
+    assert gf.marginal(name) == FPS(f'{name}^3')
+    assert gf.update(
+        parse_expr(f'{name} = {name} + 1')) == FPS(f'{name}^4*x^5')
 
-    assert ProdigyPGF.bernoulli('sum', '1/2') == FPS('1/2+1/2*sum', 'sum')
+    assert ProdigyPGF.bernoulli(name, '1/2') == FPS(f'1/2+1/2*{name}')
 
     pygin.reset_symbol_cache()
-    gf = FPS('sum*x', 'x')
+    gf = FPS(f'{name}*x', 'x')
     assert len(gf.get_parameters()) == 1
-    assert gf.update(parse_expr('x = 2')) == FPS('sum*x^2', 'x')
+    assert gf.update(parse_expr('x = 2')) == FPS(f'{name}*x^2', 'x')

--- a/tests/distribution/sympy/test_PGFS_factory.py
+++ b/tests/distribution/sympy/test_PGFS_factory.py
@@ -27,7 +27,7 @@ def test_geometric(probability):
                           for i, j in itertools.product(range(10), range(10))])
 def test_uniform(start, end):
     assert GeneratingFunction(f"variable**{start} / ({end} - {start}+1) *"
-                              f"(variable ** ({end} - {start} + 1) - 1) / (variable - 1)") == \
+                              f"(variable ** ({end} - {start} + 1) - 1) / (variable - 1)", 'variable') == \
            SympyPGF.uniform("variable", str(start), str(end))
 
 

--- a/tests/distribution/sympy/test_PGFS_factory.py
+++ b/tests/distribution/sympy/test_PGFS_factory.py
@@ -1,47 +1,53 @@
+import itertools
 import random as rng
+
+import pytest
 
 from prodigy.distribution.generating_function import (GeneratingFunction,
                                                       SympyPGF)
 
 
-def test_bernoulli():
-    probability = str(rng.random())
+@pytest.mark.parametrize('probability',
+                         [str(rng.random()) for _ in range(100)])
+def test_bernoulli(probability):
     assert GeneratingFunction(
         f"1-{probability} + {probability}* variable") == SympyPGF.bernoulli(
             "variable", probability)
 
 
-def test_geometric():
-    probability = str(rng.random())
+@pytest.mark.parametrize('probability',
+                         [str(rng.random()) for _ in range(100)])
+def test_geometric(probability):
     assert GeneratingFunction(f"{probability}/(1- (1-{probability})*variable)"
                               ) == SympyPGF.geometric("variable", probability)
 
 
-def test_uniform():
-    start = rng.randint(0, 10)
-    end = start + rng.randint(0, 10)
+@pytest.mark.parametrize('start,end',
+                         [(i, i + j)
+                          for i, j in itertools.product(range(10), range(10))])
+def test_uniform(start, end):
     assert GeneratingFunction(f"variable**{start} / ({end} - {start}+1) *"
                               f"(variable ** ({end} - {start} + 1) - 1) / (variable - 1)") == \
            SympyPGF.uniform("variable", str(start), str(end))
 
 
-def test_log():
-    probability = str(rng.random())
+@pytest.mark.parametrize('probability',
+                         [str(rng.random()) for _ in range(100)])
+def test_log(probability):
     assert GeneratingFunction(
         f"log(1-{probability}*variable)/log(1-{probability})") == SympyPGF.log(
             "variable", probability)
 
 
-def test_poisson():
-    rate = str(rng.randint(0, 10))
+@pytest.mark.parametrize('rate', range(10))
+def test_poisson(rate):
     hand = GeneratingFunction(f"exp({rate} * (variable -1))", "variable")
     factory = SympyPGF.poisson("variable", str(rate))
     assert hand == factory
 
 
-def test_binomial():
-    n = rng.randint(0, 20)
-    p = rng.random()
+@pytest.mark.parametrize('n,p', [(i, rng.random()) for i in range(20)])
+def test_binomial(n, p):
     assert GeneratingFunction(f"(1-{p}+{p}*variable)**{n}",
                               "variable") == SympyPGF.binomial(
                                   "variable", str(n), str(p))

--- a/tests/distribution/sympy/test_generating_function.py
+++ b/tests/distribution/sympy/test_generating_function.py
@@ -303,6 +303,11 @@ def test_predefined_variable_names():
     gf = GeneratingFunction('sum^3*x^5', 'sum', 'x')
     assert len(gf.get_variables()) == 2
     assert gf.marginal('sum') == GeneratingFunction('sum^3', 'sum')
-    pytest.xfail('known issue, low priority')
     assert gf.update(parse_expr('sum = sum + 1')) == GeneratingFunction(
         'sum^4*x^5', 'sum', 'x')
+
+    assert SympyPGF.bernoulli('sum', '1/2') == GeneratingFunction(
+        '1/2+1/2*sum', 'sum')
+    gf = GeneratingFunction('sum*x', 'x')
+    assert len(gf.get_parameters()) == 1
+    assert gf.update(parse_expr('x = 2')) == GeneratingFunction('sum*x^2', 'x')

--- a/tests/distribution/sympy/test_generating_function.py
+++ b/tests/distribution/sympy/test_generating_function.py
@@ -26,7 +26,7 @@ def create_random_gf(number_of_variables: int = 1, terms: int = 1):
         for var in symbols:
             monomial *= var**values[i]
         result += monomial * coeffs[i]
-    return GeneratingFunction(result, *symbols)
+    return GeneratingFunction(str(result), *symbols)
 
 
 class TestDistributionInterface:
@@ -300,14 +300,14 @@ def test_split_addend():
 
 
 def test_predefined_variable_names():
-    gf = GeneratingFunction('sum^3*x^5', 'sum', 'x')
+    gf = GeneratingFunction('sum^3*x^5')
     assert len(gf.get_variables()) == 2
-    assert gf.marginal('sum') == GeneratingFunction('sum^3', 'sum')
-    assert gf.update(parse_expr('sum = sum + 1')) == GeneratingFunction(
-        'sum^4*x^5', 'sum', 'x')
+    assert gf.marginal('sum') == GeneratingFunction('sum^3')
+    assert gf.update(
+        parse_expr('sum = sum + 1')) == GeneratingFunction('sum^4*x^5')
 
     assert SympyPGF.bernoulli('sum', '1/2') == GeneratingFunction(
-        '1/2+1/2*sum', 'sum')
+        '1/2+1/2*sum')
     gf = GeneratingFunction('sum*x', 'x')
     assert len(gf.get_parameters()) == 1
     assert gf.update(parse_expr('x = 2')) == GeneratingFunction('sum*x^2', 'x')

--- a/tests/distribution/sympy/test_generating_function.py
+++ b/tests/distribution/sympy/test_generating_function.py
@@ -299,15 +299,17 @@ def test_split_addend():
     assert GeneratingFunction._split_addend(addend) == (probability, monomial)
 
 
-def test_predefined_variable_names():
-    gf = GeneratingFunction('sum^3*x^5')
+@pytest.mark.parametrize("name", ['sum', 'exp', 'sign', 'ln', 'log', 'sqrt'])
+def test_predefined_variable_names(name):
+    gf = GeneratingFunction(f'{name}^3*x^5')
     assert len(gf.get_variables()) == 2
-    assert gf.marginal('sum') == GeneratingFunction('sum^3')
-    assert gf.update(
-        parse_expr('sum = sum + 1')) == GeneratingFunction('sum^4*x^5')
+    assert gf.marginal(name) == GeneratingFunction(f'{name}^3')
+    assert gf.update(parse_expr(f'{name} = {name} + 1')) == GeneratingFunction(
+        f'{name}^4*x^5')
 
-    assert SympyPGF.bernoulli('sum', '1/2') == GeneratingFunction(
-        '1/2+1/2*sum')
-    gf = GeneratingFunction('sum*x', 'x')
+    assert SympyPGF.bernoulli(name,
+                              '1/2') == GeneratingFunction(f'1/2+1/2*{name}')
+    gf = GeneratingFunction(f'{name}*x', 'x')
     assert len(gf.get_parameters()) == 1
-    assert gf.update(parse_expr('x = 2')) == GeneratingFunction('sum*x^2', 'x')
+    assert gf.update(parse_expr('x = 2')) == GeneratingFunction(
+        f'{name}*x^2', 'x')


### PR DESCRIPTION
This pull request is mainly intended as a fix for #14. Even though the problem itself is quite simple, the solution was more complicated than anticipated. I implemented an entirely new sympy parser that we can now use instead of `sympy.S`. If given a complex expression as a string, it will call the internal sympy parsing function (same as `sympy.S`), but additionally:

- It only detects predefined function names if these symbols are actually used as a function. I.e., we can now have variables named `log` or `exp`, which wasn't possible previously, because these names were immediately parsed as their corresponding functions - even if they weren't used as a function but as a symbol (note that is is possible to tell `sympy.S` to interpret these names as symbols, but then they can no longer be used as functions).
- Automatically assumes that all parsed symbols are rational and nonnegative unless specified otherwise.
EDIT: In some rare cases, this seems to make sympy much slower for some reason. But it's still correct, right? Because these assumptions existed before as well, they just weren't properly implemented.
- Allows for direct parsing from a `probably.Expr` to a `sympy.Expr`, which is much faster than first converting the `probably.Expr` to a string and then parsing that string with `sympy`.

As for some additional minor improvements that came up naturally during the implementations of the new parser:

- A lot of unnecessary conversions of objects to strings and then to `sympy` objects are removed (see f8edbcee1f9a55f2bcf368fe60178efcef591a5a and 1e272bca67e8163298a261216d5661d9bfd69a75).
- A lot of our test cases are now parameterized, mainly such that they now run on both backends and rely on randomness to a lesser extent (for the latter, see b5483c52f0c3a1903cefd2fc104bdff16cabedd5).
- In our CI workflow, the tests are immediately cancelled if one fails in order to preserve precious minutes.
- Some bugfixes.

All in all, the runtime of the `sympy` backend is improved by about (using a **very** rough benchmark I did) 10%.