### PR TITLE
Automatically installs z3 solver with prodigy

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ To install Prodigy, follow these steps:
 1. Make sure [Python](https://www.python.org/downloads/) 3.9 or newer is installed.
 2. Install [GiNaC](https://www.ginac.de/Download.html), which also requires [CLN](https://www.ginac.de/CLN/).
 3. Install [Poetry](https://python-poetry.org/docs/#installation).
-4. Clone or download the Prodigy repository, open a command prompt in its root folder, and type `poetry install`. This should automatically install all required dependencies.
+4. Clone or download the Prodigy repository, open a command prompt in its root folder, and type `./install.sh`. This should automatically install all required dependencies.
 
 If no errors occurred, you have successfully installed Prodigy.
 Now there are two options on how to use the tool. You can either use the command-line interface (CLI) or use the webservice frontend. The next section (_Basic Usage_) details how to achieve both of these things.

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Install poetry packages
+poetry install
+
+# Install z3 solver
+pysmt-install --z3 --confirm-agreement

--- a/install.sh
+++ b/install.sh
@@ -4,4 +4,4 @@
 poetry install
 
 # Install z3 solver
-pysmt-install --z3 --confirm-agreement
+poetry run pysmt-install --z3 --confirm-agreement

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ numpy = "1.26.4"
 # https://stackoverflow.com/questions/77507580/userwarning-figurecanvasagg-is-non-interactive-and-thus-cannot-be-shown-plt-sh
 pyqt6 = "^6.7.1"
 symengine = "^0.11.0"
+setuptools = "^76.0.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.2.5"


### PR DESCRIPTION
## Changelog

#### Added
* Automatically installs the z3 solver when installing prodigy (closes #58)
* Package `setuptools` as requirement for `pysmt-install`

#### Changed
* README installation guide